### PR TITLE
Fix chat API CORS preflight handling

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,5 +1,4 @@
 const express = require('express');
-const cors = require('cors');
 const dotenv = require('dotenv');
 
 // Load environment variables from .env file
@@ -7,15 +6,34 @@ dotenv.config();
 
 const app = express();
 const PORT = process.env.PORT || 3001;
+const ALLOWED_ORIGINS = new Set([
+  'https://iflytek.github.io',
+  'http://localhost:5173',
+  'http://127.0.0.1:5173'
+]);
+
+function applyCors(req, res) {
+  const requestOrigin = req.headers.origin;
+
+  if (requestOrigin && ALLOWED_ORIGINS.has(requestOrigin)) {
+    res.setHeader('Access-Control-Allow-Origin', requestOrigin);
+    res.setHeader('Vary', 'Origin');
+  }
+
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type,Authorization');
+}
 
 // Middleware
-// Allow all origins with explicit CORS options for preflight support
-app.use(cors({
-  origin: '*',
-  methods: ['GET', 'POST', 'OPTIONS'],
-  allowedHeaders: ['Content-Type', 'Authorization']
-}));
-app.options('*', cors());
+app.use((req, res, next) => {
+  applyCors(req, res);
+
+  if (req.method === 'OPTIONS') {
+    return res.sendStatus(204);
+  }
+
+  next();
+});
 app.use(express.json());
 
 // Proxy endpoint for chat completions


### PR DESCRIPTION
### Motivation
- The browser was blocking requests to `/api/chat` with `No 'Access-Control-Allow-Origin' header is present` because the preflight `OPTIONS` response did not consistently include CORS headers, so the server must always respond to preflight and expose the expected headers.

### Description
- Removed the generic `cors()` middleware and added a whitelist `ALLOWED_ORIGINS` set including `https://iflytek.github.io` and local Vite origins.
- Added `applyCors` to set `Access-Control-Allow-Origin`, `Vary`, `Access-Control-Allow-Methods`, and `Access-Control-Allow-Headers` when the request `Origin` matches the whitelist.
- Added a middleware that applies CORS headers and immediately returns `204` for `OPTIONS` requests while leaving the existing `/api/chat` proxy logic intact.

### Testing
- Ran a syntax check with `node -c server.js`, which succeeded.
- Sent a preflight check with `curl -i -X OPTIONS 'http://127.0.0.1:3001/api/chat' -H 'Origin: https://iflytek.github.io' -H 'Access-Control-Request-Method: POST' -H 'Access-Control-Request-Headers: content-type'`, which returned `204 No Content` with the expected CORS headers.
- Sent a test `POST` with `curl` which reached the server and included CORS headers but the upstream proxy `fetch` failed in this environment (so POST reachability to the external API remains an external/network issue).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bba2f12170832696336dbc5d3725d7)