### PR TITLE
[Docs] Improve English translation quality and sync with Chinese docs

### DIFF
--- a/docs/en/guide/astronclaw/channels.md
+++ b/docs/en/guide/astronclaw/channels.md
@@ -145,7 +145,7 @@ Use WeChat to scan the QR code above, and click "Connect" on the pop-up page to 
 Open the Weibo client and send a private message to `https://weibo.com/u/6808810981`
 ![Private Message Weibo Account](/astronclaw/channels/weibo-app-credential1.png)
 
-Send private message: `Connect Lobster`. Get the app credentials:
+Send private message: `连接龙虾`. Get the app credentials:
 ![Get Weibo Credentials](/astronclaw/channels/weibo-app-credential2.png)
 
 **Step 2: Complete Configuration in AstronClaw**

--- a/docs/en/guide/astronclaw/getting-started.md
+++ b/docs/en/guide/astronclaw/getting-started.md
@@ -31,4 +31,4 @@ Enter the **Channel Configuration** page to connect to enterprise collaboration 
 *   DingTalk Channel
 *   WeCom Channel
 
-With just a simple configuration of the relevant App ID and credentials, your digital lobster can be on standby at any time in these chat softwares!
+With just a simple configuration of the relevant App ID and credentials, your digital lobster can be on standby at any time in these chat applications!

--- a/docs/en/guide/astronclaw/introduction.md
+++ b/docs/en/guide/astronclaw/introduction.md
@@ -28,5 +28,5 @@ Reading time: about 5 minutes
 | Environment | No dependencies needed | Needs Node, Docker, etc. |
 | Skills Install | One-click from Skill Market | Manual search, download, install |
 | Uptime | Cloud 24/7 running | Stops when computer is off |
-| Channels | Feishu, DingTalk, WeCom, Weibo | Needs manual configuration |
+| Channels | Feishu, DingTalk, WeCom, WeChat, Weibo | Needs manual configuration |
 | Maintenance | Platform hosted, zero ops | Needs self-hosted server or PC on |

--- a/docs/en/guide/loomy/faq.md
+++ b/docs/en/guide/loomy/faq.md
@@ -1,6 +1,6 @@
 # Frequently Asked Questions (FAQ)
 
-## Privacy and Security Related
+## Privacy and Security
 
 ### Will my files be uploaded to the cloud?
 
@@ -12,7 +12,7 @@ Loomy can only access the **working directories you explicitly authorize**. For 
 
 ### Can Loomy use my own model service provider API Key?
 
-Yes. Loomy provides default model services for users out of the box; if you have your own model service provider, you can also configure your own API Key in Loomy to use.
+Yes. Loomy provides default model services for out-of-the-box use; if you have your own model service provider, you can also configure your API Key in Loomy.
 When you use your own API Key, Loomy will not upload any additional confidential information. The relevant Key will only be saved locally and used locally when you initiate the corresponding model call, and will not be hosted or synchronized to the cloud by the Loomy platform.
 
 ## Target Audience
@@ -27,4 +27,4 @@ Loomy is suitable for people who need to frequently handle information organizat
 *   E-commerce practitioners
 *   Individual users who hope to hand over repetitive processes to AI for assistance
 
-If your work frequently requires switching back and forth between chats, emails, documents, web pages, and to-dos, Loomy will be easier to play its value.
+If your work frequently requires switching back and forth between chats, emails, documents, web pages, and to-dos, Loomy can more easily deliver its value.

--- a/docs/en/guide/loomy/introduction.md
+++ b/docs/en/guide/loomy/introduction.md
@@ -1,20 +1,16 @@
-# Loomy: Your Desktop Companion
+# Loomy: Your Desktop AI Companion
 
-Loomy is a desktop application based on the OpenClaw framework. It goes beyond web-based AI assistants by directly integrating with your local operating system and files, becoming your reliable work companion.
+**Loomy** is an AI work companion designed for real-world office scenarios. Built on AstronClaw's powerful underlying engine, it focuses on four core principles: **low barrier, high security, strong adaptability, and proactive collaboration**, helping users truly execute complex, repetitive, and cross-tool workflows.
 
----
+Compared to geek-oriented and complex-to-deploy Agent tools, Loomy emphasizes **out-of-the-box usability** and **compatibility with the Chinese office environment**.
 
-## Why Loomy?
+## Why Choose Loomy?
 
-While cloud assistants (like AstronClaw) are great for anytime, anywhere access, many professional tasks require deep interaction with local files, applications, and operating systems. Loomy fills this gap by offering:
+*   **Easy to Get Started**: No need to fiddle with command lines or complex environment configurations. Just complete basic authorization and tool binding, and you can start using AI chat, task management, working directory switching, remote collaboration, and more.
+*   **More Than Just "Following Instructions"**: Loomy doesn't just want to be an assistant that follows instructions, but a work partner more like a colleague. It can break down tasks around user goals, connect multiple tools, and execute multi-step workflows.
+*   **Understands Your Habits**: Gradually understands user habits during daily use, providing a collaboration experience closer to actual work.
 
-1.  **Local Context**: Directly read and edit local files without uploading them manually.
-2.  **OS Integration**: Automate system tasks, manage calendars, or send emails through local clients.
-3.  **Privacy Control**: Sensitive data stays on your machine, processed securely.
+## Security and Practicality
 
-## Key Features
-
-*   **File Mastery**: Drag, drop, and process documents (Word, Excel, PDF) natively.
-*   **Skill Toolbox**: Extend capabilities with customized local skills.
-*   **Scheduled Tasks**: Run background operations even when you are away from the keyboard.
-*   **Remote Control**: Trigger local actions remotely via mobile apps like WeChat or Feishu.
+In terms of product positioning, Loomy also particularly emphasizes security and practicality.
+Through **directory-level authorization**, **enterprise scenario adaptation**, **localized tool integration**, and other methods, it minimizes data risks and deployment barriers, allowing AI to truly enter team workflows instead of staying at the demo stage.

--- a/docs/en/guide/loomy/quick-start.md
+++ b/docs/en/guide/loomy/quick-start.md
@@ -6,7 +6,7 @@ First, apply to join the Waiting List on the official website, submit basic info
 ![Join Waiting List](/loomy/quick-start/waiting.png)
 
 ## Get Invitation Code
-After your application is approved, you will receive an exclusive invitation code. The invitation code is a necessary credential to log in and experience Loomy currently, please keep it safe.
+After your application is approved, you will receive an exclusive invitation code. The invitation code is a necessary credential to log in and experience Loomy — please keep it safe.
 
 ![Get Invitation Code](/loomy/quick-start/qmail.png)
 

--- a/docs/en/guide/loomy/scenarios.md
+++ b/docs/en/guide/loomy/scenarios.md
@@ -2,7 +2,7 @@
 
 Loomy is suitable for work scenarios that require frequent switching between information organization, content creation, task execution, and cross-tool collaboration, especially for individual workers, small teams, and high-frequency office users.
 
-Here are a few typical landing scenarios for Loomy:
+Here are a few typical use cases for Loomy:
 
 ## 1. Morning Smart Broadcast
 Want to quickly know today's important information? Loomy can help you integrate weather, emails, schedules, and hot news to generate an exclusive morning broadcast, allowing you to calmly start a new day.
@@ -29,8 +29,8 @@ Need to review your learning progress? Loomy can help you analyze the execution 
 > Help me review the execution rate this week, analyze where I easily break off, and how to adjust next week's plan to be more realistic.
 
 Loomy will do for you:
-*   **Execution Rate Analysis**: Calculate this week's completion degree, identify the gap between plan and reality
-*   **Breakpoint Diagnosis**: Analyze time nodes and reasons for easy interruption of learning
+*   **Completion Analysis**: Calculate this week's completion rate, identify the gap between plan and reality
+*   **Bottleneck Diagnosis**: Analyze time nodes and reasons for easy interruption of learning
 *   **Plan Optimization**: Based on actual conditions, adjust the rhythm and task volume of next week's plan
 *   **Reminder Suggestions**: Give reminder suggestions at key time points to maintain learning continuity
 
@@ -43,14 +43,14 @@ From topic planning to content publishing, and then to data review, Loomy string
 > I operate a Douyin account positioned on tech and digital reviews. Recently the traffic has dropped a bit, help me analyze what hot topics are in the tech circle this week, recommend 3 topic directions for me, and give the title, core selling point, and estimated audience reaction for each direction.
 
 Loomy will help you:
-*   **Hotspot Tracking**: Crawl hot topics in the circle in real-time, analyze discussion heat and trend directions
+*   **Trend Tracking**: Track hot topics in the circle in real time, analyze discussion heat and trend directions
 *   **Topic Recommendation**: Combine account positioning to recommend high-potential topic directions
-*   **First Draft Generation**: After selecting a topic, quickly generate video scripts or image-text first drafts
+*   **Draft Generation**: After selecting a topic, quickly generate video scripts or image-text drafts
 
 ![Content Creation and Operation](/loomy/scenarios/case2.png)
 
 ## 4. Intelligent Document Management
-Loomy opens up file organization, knowledge precipitation, and content output links, turning fragmented work into a reusable efficient process.
+Loomy opens up file organization, knowledge retention, and content output, turning fragmented work into a reusable efficient process.
 
 **Usage Scenario**
 > I have a pile of messy files piled up in my download folder, and a few screenshots saved casually. Help me automatically classify and archive by type and project, set up the folder structure, and tell me how you archived them.
@@ -70,8 +70,8 @@ Loomy helps e-commerce practitioners quickly get product information, analyze ma
 > Open JD.com, save the top ten products on the homepage, as well as their design copy, order sales, and other information locally. Suppose I am going to promote these ten products in a live broadcast now, how should I design the live broadcast script?
 
 Loomy will help you:
-*   **Product Information Crawling**: Extract detailed information of the top ten products on the product page
-*   **Selling Point Extraction**: Analyze product advantages, extract core selling points, highlight cost-effectiveness and user pain points
-*   **Script Generation**: Based on product features and sales data, generate attractive live broadcast scripts for each product
+*   **Product Information Extraction**: Extract detailed information of the top ten products on the product page
+*   **Key Selling Points**: Analyze product advantages, extract core selling points, highlight cost-effectiveness and user pain points
+*   **Live Stream Script**: Based on product features and sales data, generate attractive live broadcast scripts for each product
 
 ![E-commerce Live Broadcast Assistant](/loomy/scenarios/case5.png)

--- a/docs/en/guide/loomy/scheduled-tasks.md
+++ b/docs/en/guide/loomy/scheduled-tasks.md
@@ -68,8 +68,8 @@ That is to say:
 Whether it involves the consumption of other capabilities is subject to the current rules and actual function descriptions within the product.
 
 > **API Key Security Instructions**
-> The API Key you configure yourself will only be saved on your local device, and Loomy will not host, upload, or leak these key information.
-> **Keep your keys safe**: API Keys are sensitive information, please do not share them randomly with others, and do not save or transmit them in untrusted environments. If the key is leaked, it may cause a third party to fraudulently use your model service quota or access capabilities.
+> The API Key you configure yourself will only be saved on your local device. Loomy will not host, upload, or leak this key information.
+> **Keep your keys safe**: API Keys are sensitive information, please do not share them randomly with others, and do not save or transmit them in untrusted environments. If the key is leaked, it may allow a third party to misuse your model service quota or access capabilities.
 
 ### How to get points
 You can get points in the following ways:

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -17,21 +17,21 @@ hero:
 
 features:
   - title: 01 One-Click Cloud Deployment
-    details: Minimalist process, zero code configuration, farewell to environment dependencies. Runs 24/7 in the cloud, available anytime, anywhere.
+    details: Minimal setup, zero code configuration, no environment dependencies. Runs 24/7 in the cloud, available anytime, anywhere.
     link: /en/guide/astronclaw/getting-started
   - title: 02 Rich Built-in Skills System
-    details: Supports 130+ official skills, one-click installation and use. Also supports conversational automatic installation and custom skill expansion.
+    details: Supports 130+ official skills with one-click installation. Also supports auto-installation via chat and custom skill creation.
     link: /en/guide/astronclaw/skills
   - title: 03 24/7 Multi-Channel Response
-    details: Supports seamless integration with Feishu, DingTalk, and WeCom. Complete daily tasks in your familiar office collaboration software.
+    details: Seamlessly integrates with Feishu, DingTalk, and WeCom. Complete daily tasks right within your familiar office tools.
   - title: 04 Loomy Desktop Deep Collaboration
-    details: Oriented towards real office scenarios, focusing on "low threshold, high security, strong adaptation, and active collaboration". Easy integration with localized tools.
+    details: Designed for real office scenarios — low barrier, high security, strong adaptability, and proactive collaboration. Easy integration with localized tools.
     link: /en/guide/loomy/introduction
-  - title: 05 Rich Typical Work Scenarios
-    details: Covers multiple real business loops such as social media operation, daily office collaboration, investment monitoring, and e-commerce operation.
+  - title: 05 Typical Work Scenarios
+    details: Covers real business workflows including social media operations, daily office collaboration, investment tracking, and e-commerce operations.
     link: /en/guide/loomy/scenarios
-  - title: 06 High Security & Zero Maintenance Cost
-    details: Platform hosting, enterprise-level security protection; Loomy's directory-level authorization ensures local data privacy, making AI land safely.
+  - title: 06 High Security & Zero Maintenance
+    details: Platform-hosted with enterprise-grade security. Loomy's directory-level authorization protects local data privacy, making AI deployment safe and reliable.
 
 ---
 


### PR DESCRIPTION
## Summary

This PR improves the English translation quality of the documentation and syncs it with the Chinese version, as part of the [Documentation Update Bounty](https://github.com/iflytek/astronclaw-tutorial/issues/17).

## Changes

### Content Sync
- Rewrite Loomy introduction (en) to match the Chinese version content structure
- Fix WeChat channel missing from AstronClaw comparison table (en introduction.md)

### Translation Quality Fixes
- Fix incorrect Weibo command translation (`Connect Lobster` → `连接龙虾`)
- Fix grammar: `chat softwares` → `chat applications`
- Fix grammar: `these key information` → `this key information`
- Improve: `knowledge precipitation` → `knowledge retention`
- Improve: `Breakpoint Diagnosis` → `Bottleneck Diagnosis`
- Improve: `Hotspot Tracking` → `Trend Tracking`
- Improve: `Product Information Crawling` → `Product Information Extraction`
- Improve homepage features descriptions (en)
- Fix `Privacy and Security Related` → `Privacy and Security`
- Fix `be easier to play its value` → `deliver its value`
- Remove unnatural `currently` from quick-start

## Testing
- Verified all changes maintain correct Markdown formatting
- Checked that image references and links remain valid

Related: #17