### PR TITLE
docs(loomy): 工具箱新增外部 MCP 配置示例（StashBase 本地知识库）

### DIFF
--- a/docs/en/guide/loomy/toolbox.md
+++ b/docs/en/guide/loomy/toolbox.md
@@ -46,6 +46,45 @@ Loomy will generate a weekly report based on your work content and send it to th
 
 ![Write and Send Emails](/loomy/toolbox/toolbox-email-send.png)
 
+### Configuration Example: Local Knowledge Base (StashBase)
+
+The toolbox also supports external custom MCP services. The following takes [StashBase](https://github.com/liliu-z/stashbase), an open-source local knowledge base app, as an example to demonstrate how to let Loomy semantically search local files on your computer (Markdown, PDF, DOCX, images, etc.).
+
+**1. Prepare StashBase**
+
+*   Install and launch the app from [StashBase Releases](https://github.com/liliu-z/stashbase/releases) (macOS / Windows / Linux supported).
+*   Open the local folders you want AI to search in StashBase. Only folders you explicitly open are indexed; semantic search requires an embedding API key configured in StashBase, while keyword search works without one.
+
+**2. Copy the MCP Configuration**
+
+Open "Settings" -> "MCP" in StashBase and copy the standard MCP configuration from the "For any other MCP-compatible agent" section. It looks like this (use the absolute `command` path you actually copied):
+
+```json
+{
+  "mcpServers": {
+    "stashbase": {
+      "command": "~/.stashbase/bin/stashbase-mcp"
+    }
+  }
+}
+```
+
+**3. Add It to the Loomy Toolbox**
+
+In Loomy "Settings" -> "Toolbox", add an external custom MCP configuration, paste the content copied in the previous step, and save.
+
+**4. Usage Scenario Example**
+
+Create a new task and send a message:
+
+> Find the payment terms in last quarter's contract in my local files
+
+Loomy will call StashBase's `search_library` tool to search matching files by meaning, then use `read_file` to read the sources (PDFs return extracted Markdown text), and answer with references.
+
+> **Note:**
+> * The StashBase desktop app must stay running while searching.
+> * StashBase also exposes file-writing tools (create, edit, delete files); set invocation permissions for them in the toolbox as needed.
+
 ### Frequently Asked Questions
 
 **How to get the QQ Mail authorization code?**

--- a/docs/guide/loomy/toolbox.md
+++ b/docs/guide/loomy/toolbox.md
@@ -46,6 +46,45 @@ Loomy 会根据你的工作内容生成周报，并通过 QQ 邮箱发送给指�
 
 ![撰写并发送邮件](/loomy/toolbox/toolbox-email-send.png)
 
+### 配置示例：接入本地知识库（StashBase）
+
+工具箱同样支持外部自定义 MCP 服务。下面以开源的本地知识库应用 [StashBase](https://github.com/liliu-z/stashbase) 为例，演示如何让 Loomy 语义检索你电脑上的本地资料（Markdown、PDF、DOCX、图片等）。
+
+**1. 准备 StashBase**
+
+*   从 [StashBase Releases](https://github.com/liliu-z/stashbase/releases) 安装并启动应用（支持 macOS / Windows / Linux）。
+*   在 StashBase 中打开你想让 AI 检索的本地文件夹。只有你主动打开的文件夹会被索引；语义搜索需要在 StashBase 中配置 embedding API Key，未配置时仍可使用关键词搜索。
+
+**2. 复制 MCP 配置**
+
+打开 StashBase 的「Settings」->「MCP」，在「For any other MCP-compatible agent」区域复制标准 MCP 配置。配置形如（`command` 以实际复制到的绝对路径为准）：
+
+```json
+{
+  "mcpServers": {
+    "stashbase": {
+      "command": "~/.stashbase/bin/stashbase-mcp"
+    }
+  }
+}
+```
+
+**3. 添加到 Loomy 工具箱**
+
+在 Loomy「设置」->「工具箱」中添加外部自定义 MCP 配置，粘贴上一步复制的内容并保存。
+
+**4. 使用场景示例**
+
+创建一个新任务，发送消息：
+
+> 在我的本地资料里找一下上季度合同中关于付款条款的内容
+
+Loomy 会调用 StashBase 的 `search_library` 工具按语义检索命中的文件，再用 `read_file` 读取原文（PDF 会返回抽取后的 Markdown 文本），并给出带出处的回答。
+
+> **注意：**
+> * 检索期间 StashBase 桌面应用需保持运行。
+> * StashBase 的文件写入类工具（创建、修改、删除文件）也会一并暴露，建议在工具箱中按需设置调用权限。
+
 ### 常见问题
 
 **QQ 邮箱授权码怎么获取？**


### PR DESCRIPTION
## 内容

工具箱文档目前提到「可随时添加外部自定义的 MCP 配置文件」，但只有内置 QQ 邮箱 MCP 的配置示例，没有外部 MCP 的完整走通示例。本 PR 在中英双语的 `toolbox.md` 各补一节「配置示例：接入本地知识库（StashBase）」：

- 以开源本地知识库应用 [StashBase](https://github.com/liliu-z/stashbase)（Apache-2.0，macOS/Windows/Linux）为例，演示外部自定义 MCP 的完整接入流程：准备本地文件夹 → 从 StashBase 设置页复制标准 MCP 配置 → 添加进 Loomy 工具箱 → 自然语言检索本地资料。
- 场景对 Loomy 用户实用：把电脑里的 PDF/DOCX/图片/Markdown 变成可语义检索的上下文，与 Loomy 已有的联网、办公能力互补。
- 附注意事项：检索期间 StashBase 需保持运行；其文件写入类工具建议按需设置调用权限。

## 说明

- 中英两份 `docs/guide/loomy/toolbox.md`、`docs/en/guide/loomy/toolbox.md` 同步更新，插入在 QQ 邮箱示例之后、常见问题之前。
- 暂无配图（本节步骤以文字即可走通）；如需要截图风格统一，我可以补。
- StashBase 侧的配置路径、工具名（`search_library` / `read_file`）已对照其源码核实。
