### PR TITLE
docs: 刷新 doc-watch 基线（上游隐私政策新增 Microsoft Clarity 小节）

### DIFF
--- a/scripts/doc-watch/baseline/loomy.json
+++ b/scripts/doc-watch/baseline/loomy.json
@@ -94,6 +94,7 @@
         "h4:2.7 本地配置存储（ electron-store ）",
         "h4:2.8 iDATA 数据服务能力",
         "h4:2.9 订单管理系统 API / 交易服务接口",
+        "h4:2.10 Microsoft Clarity 网站行为分析 SDK",
         "h3:3. 转让与公开披露",
         "h3:4. 共享、转让、公开披露个人信息时事先征得授权同意的例外",
         "h2:四、我们如何存储与保护您的信息",
@@ -112,8 +113,8 @@
         "h2:九、其他"
       ],
       "images": [],
-      "textHash": "b389e0cc9f5330c5",
-      "textLen": 14440
+      "textHash": "8877ec3235b49a7d",
+      "textLen": 14923
     },
     "https://loomy.xunfei.cn/docs/Safe/Loomy-user": {
       "url": "https://loomy.xunfei.cn/docs/Safe/Loomy-user",


### PR DESCRIPTION
## 背景

doc-watch 巡检（Issue #70）发现上游 **Loomy 隐私政策**页新增小节「2.10 Microsoft Clarity 网站行为分析 SDK」（正文 +483 字）。

## 处理

该页属于法务/隐私页，本教程站点按既定护栏不镜像其正文（源码中无 privacy 页面），因此无正文需要补全，仅刷新巡检基线以消除告警：

- 运行 `node scripts/doc-watch/check-updates.mjs --update`，`baseline/loomy.json` 记录新小节并更新该页 textHash / textLen。
- 复跑 `check-updates.mjs` 确认「✅ 两个文档源均无新增内容」。

## 来源

- 上游变更页：https://loomy.xunfei.cn/docs/Safe/Loomy-privacy

Closes #70
